### PR TITLE
Added missing become when creating .ssh

### DIFF
--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -25,6 +25,7 @@
     state: directory
 
 - name: "Install user ssh private key"
+  become: yes
   no_log: true
   copy:
     content: "{{ findit_app_user_ssh_private_key }}"
@@ -33,6 +34,7 @@
     owner: "{{ findit_app_user }}"
 
 - name: "Install user ssh public key"
+  become: yes
   no_log: true
   copy:
     content: "{{ findit_app_user_ssh_public_key }}"

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -17,6 +17,7 @@
   no_log: true
 
 - name: "Ensure .ssh dir exists"
+  become: yes
   file:
     dest: "/home/{{ findit_app_user }}/.ssh"
     mode: 0700


### PR DESCRIPTION
Using ansible 2.6 highlight the following issues
- old prereqs in default dir, remove
- remove the use of become with include, does not work
- use become: yes (old become: true)